### PR TITLE
chore(renovate): fix renovate kali deps configs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,12 +24,12 @@
       ],
       "separateMajorMinor": false,
       "groupName": "kali-linux",
-      "matchPackagePatterns": [
-        "/^kali_rolling//",
-        "kalilinux/kali-rolling"
-      ],
       "semanticCommitType": "fix",
-      "automerge": true
+      "automerge": true,
+      "matchPackageNames": [
+        "//^kali_rolling///",
+        "/kalilinux/kali-rolling/"
+      ]
     },
     {
       "matchDatasources": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,11 +23,13 @@
         "repology"
       ],
       "separateMajorMinor": false,
-      "groupName": "kali-linux packages",
-      "matchPackageNames": [
-        "/^kali_rolling//"
+      "groupName": "kali-linux",
+      "matchPackagePatterns": [
+        "/^kali_rolling//",
+        "kalilinux/kali-rolling"
       ],
-      "semanticCommitType": "fix"
+      "semanticCommitType": "fix",
+      "automerge": true
     },
     {
       "matchDatasources": [


### PR DESCRIPTION
Changed to automatically merge all kali linux dependencies together in a batch.